### PR TITLE
Renamed ImageFile to UploadFile and modified iOS actual to use NSData instead of UIImage

### DIFF
--- a/aws-s3/src/androidMain/kotlin/com/estivensh4/s3/AWSS3.kt
+++ b/aws-s3/src/androidMain/kotlin/com/estivensh4/s3/AWSS3.kt
@@ -460,7 +460,7 @@ actual class AWSS3 actual constructor(
      *
      * @param bucketName The name of an existing bucket, to which you have permission.
      * @param key The key under which to store the specified file.
-     * @param imageFile The file containing the data to be uploaded to Amazon S3.
+     * @param uploadFile The file containing the data to be uploaded to Amazon S3.
      * @return A [PutObjectResult] object containing the information
      * returned by Amazon S3 for the newly created object.
      * @throws AwsException If any errors are encountered in the client
@@ -470,12 +470,12 @@ actual class AWSS3 actual constructor(
     actual suspend fun putObject(
         bucketName: String,
         key: String,
-        imageFile: ImageFile
+        uploadFile: UploadFile
     ): PutObjectResult {
         val result = client.putObject(
             bucketName,
             key,
-            imageFile.toByteArray().inputStream(),
+            uploadFile.toByteArray().inputStream(),
             ObjectMetadata()
         )
         return PutObjectResult(

--- a/aws-s3/src/androidMain/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/androidMain/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -7,7 +7,7 @@ package com.estivensh4.s3
 import android.content.ContentResolver
 import android.net.Uri
 
-actual class ImageFile constructor(
+actual class UploadFile constructor(
     private val uri: Uri,
     private val contentResolver: ContentResolver,
 ) {
@@ -18,6 +18,6 @@ actual class ImageFile constructor(
     }
 }
 
-fun Uri.toImageFile(contentResolver: ContentResolver): ImageFile {
-    return ImageFile(this, contentResolver)
+fun Uri.toUploadFile(contentResolver: ContentResolver): UploadFile {
+    return UploadFile(this, contentResolver)
 }

--- a/aws-s3/src/androidUnitTest/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/androidUnitTest/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -6,6 +6,6 @@ package com.estivensh4.s3
 
 import io.mockk.mockk
 
-actual fun createImageFileForTest(): ImageFile {
+actual fun createUploadFileForTest(): UploadFile {
     return mockk(relaxed = true)
 }

--- a/aws-s3/src/commonMain/kotlin/com/estivensh4/s3/AWSS3.kt
+++ b/aws-s3/src/commonMain/kotlin/com/estivensh4/s3/AWSS3.kt
@@ -364,7 +364,7 @@ expect class AWSS3 constructor(
      *
      * @param bucketName The name of an existing bucket, to which you have permission.
      * @param key The key under which to store the specified file.
-     * @param imageFile The file containing the data to be uploaded to Amazon S3.
+     * @param uploadFile The file containing the data to be uploaded to Amazon S3.
      * @return A [PutObjectResult] object containing the information
      * returned by Amazon S3 for the newly created object.
      * @throws AwsException If any errors are encountered in the client
@@ -374,7 +374,7 @@ expect class AWSS3 constructor(
     suspend fun putObject(
         bucketName: String,
         key: String,
-        imageFile: ImageFile
+        uploadFile: UploadFile
     ): PutObjectResult
 
     /**

--- a/aws-s3/src/commonMain/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/commonMain/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -4,4 +4,6 @@
 
 package com.estivensh4.s3
 
-expect fun createImageFileForTest(): ImageFile
+expect class UploadFile {
+    fun toByteArray(): ByteArray
+}

--- a/aws-s3/src/commonTest/kotlin/com/estivensh4/s3/AWSS3CommonTest.kt
+++ b/aws-s3/src/commonTest/kotlin/com/estivensh4/s3/AWSS3CommonTest.kt
@@ -232,7 +232,7 @@ class AWSS3CommonTest {
         val result = client.putObject(
             bucketName = bucketName,
             key = key,
-            imageFile = createImageFileForTest()
+            uploadFile = createUploadFileForTest()
         )
 
         assertNotNull(result.eTag)

--- a/aws-s3/src/commonTest/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/commonTest/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -4,6 +4,4 @@
 
 package com.estivensh4.s3
 
-expect class ImageFile {
-    fun toByteArray(): ByteArray
-}
+expect fun createUploadFileForTest(): UploadFile

--- a/aws-s3/src/iosMain/kotlin/com/estivensh4/s3/AWSS3.kt
+++ b/aws-s3/src/iosMain/kotlin/com/estivensh4/s3/AWSS3.kt
@@ -521,7 +521,7 @@ actual class AWSS3 actual constructor(
      *
      * @param bucketName The name of an existing bucket, to which you have permission.
      * @param key The key under which to store the specified file.
-     * @param imageFile The file containing the data to be uploaded to Amazon S3.
+     * @param uploadFile The file containing the data to be uploaded to Amazon S3.
      * @return A [PutObjectResult] object containing the information
      * returned by Amazon S3 for the newly created object.
      * @throws AwsException If any errors are encountered in the client
@@ -531,12 +531,12 @@ actual class AWSS3 actual constructor(
     actual suspend fun putObject(
         bucketName: String,
         key: String,
-        imageFile: ImageFile
+        uploadFile: UploadFile
     ): PutObjectResult {
         val putObjectRequest = AWSS3PutObjectRequest().apply {
             this.bucket = bucketName
             this.key = key
-            this.body = imageFile.toByteArray()
+            this.body = uploadFile.toByteArray()
         }
         val result = awaitResult { client.putObject(putObjectRequest, it) }
         return PutObjectResult(

--- a/aws-s3/src/iosMain/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/iosMain/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -9,14 +9,15 @@ import kotlinx.cinterop.addressOf
 import kotlinx.cinterop.usePinned
 import platform.Foundation.NSData
 import platform.UIKit.UIImage
+import platform.UIKit.UIImageJPEGRepresentation
 import platform.UIKit.UIImagePNGRepresentation
 import platform.posix.memcpy
 
-actual class ImageFile constructor(
-    private val uiImage: UIImage
+actual class UploadFile constructor(
+    private val data: NSData
 ) {
     actual fun toByteArray(): ByteArray {
-        return UIImagePNGRepresentation(uiImage)?.toByteArray() ?: emptyArray<Byte>().toByteArray()
+        return data.toByteArray()
     }
 
     @OptIn(ExperimentalForeignApi::class)
@@ -25,4 +26,9 @@ actual class ImageFile constructor(
             memcpy(it.addressOf(0), bytes, length)
         }
     }
+}
+
+fun UIImage.toPNGUploadFile() : UploadFile {
+    val data = UIImagePNGRepresentation(this) ?: throw Exception("Could not convert uiImage")
+    return UploadFile(data)
 }

--- a/aws-s3/src/iosTest/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/iosTest/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -6,8 +6,6 @@ package com.estivensh4.s3
 
 import platform.UIKit.UIImage
 
-actual fun createImageFileForTest(): ImageFile {
-    return ImageFile(
-        uiImage = UIImage()
-    )
+actual fun createUploadFileForTest(): UploadFile {
+    return UIImage().toPNGUploadFile()
 }

--- a/aws-s3/src/jvmMain/kotlin/com/estivensh4/s3/AWSS3.kt
+++ b/aws-s3/src/jvmMain/kotlin/com/estivensh4/s3/AWSS3.kt
@@ -486,7 +486,7 @@ actual class AWSS3 actual constructor(
      *
      * @param bucketName The name of an existing bucket, to which you have permission.
      * @param key The key under which to store the specified file.
-     * @param imageFile The file containing the data to be uploaded to Amazon S3.
+     * @param uploadFile The file containing the data to be uploaded to Amazon S3.
      * @return A [PutObjectResult] object containing the information
      * returned by Amazon S3 for the newly created object.
      * @throws AwsException If any errors are encountered in the client
@@ -496,12 +496,12 @@ actual class AWSS3 actual constructor(
     actual suspend fun putObject(
         bucketName: String,
         key: String,
-        imageFile: ImageFile
+        uploadFile: UploadFile
     ): PutObjectResult {
         val result = client.putObject(
             bucketName,
             key,
-            imageFile.toByteArray().inputStream(),
+            uploadFile.toByteArray().inputStream(),
             ObjectMetadata()
         )
         return PutObjectResult(

--- a/aws-s3/src/jvmMain/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/jvmMain/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -6,7 +6,7 @@ package com.estivensh4.s3
 
 import java.net.URI
 
-actual class ImageFile constructor(
+actual class UploadFile constructor(
     private val uri: URI
 ) {
     actual fun toByteArray(): ByteArray {
@@ -17,6 +17,6 @@ actual class ImageFile constructor(
     }
 }
 
-fun URI.toImageFile(): ImageFile {
-    return ImageFile(this)
+fun URI.toUploadFile(): UploadFile {
+    return UploadFile(this)
 }

--- a/aws-s3/src/jvmTest/kotlin/com/estivensh4/s3/UploadFile.kt
+++ b/aws-s3/src/jvmTest/kotlin/com/estivensh4/s3/UploadFile.kt
@@ -6,6 +6,6 @@ package com.estivensh4.s3
 
 import io.mockk.mockk
 
-actual fun createImageFileForTest(): ImageFile {
+actual fun createUploadFileForTest(): UploadFile {
     return mockk(relaxed = true)
 }

--- a/doc/Writerside/topics/S3.md
+++ b/doc/Writerside/topics/S3.md
@@ -118,9 +118,9 @@ fun deleteBucket(bucketName: String) {
 
 ### Put object
 <code-block lang="kotlin">
-fun putObject(bucketName: String, key: String, imageFile: ImageFile) {
+fun putObject(bucketName: String, key: String, uploadFile: UploadFile) {
     GlobalScope.launch {
-        client.putObject(bucketName, key, imageFile)
+        client.putObject(bucketName, key, uploadFile)
     }
 }
 </code-block>

--- a/samples/androidapp/src/main/java/com/estivensh4/androidapp/MainActivity.kt
+++ b/samples/androidapp/src/main/java/com/estivensh4/androidapp/MainActivity.kt
@@ -21,7 +21,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
 import com.estivensh4.androidapp.ui.theme.AwskmpTheme
-import com.estivensh4.s3.ImageFile
+import com.estivensh4.s3.UploadFile
 import com.estivensh4.shared.SampleViewModel
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit
@@ -60,7 +60,7 @@ fun Greeting() {
             sampleViewModel.putObject(
                 bucketName,
                 key,
-                ImageFile(
+                UploadFile(
                     uri = it,
                     contentResolver = context.contentResolver
                 )

--- a/samples/desktopApp/src/main/kotlin/Main.kt
+++ b/samples/desktopApp/src/main/kotlin/Main.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.AwtWindow
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import com.estivensh4.s3.ImageFile
+import com.estivensh4.s3.UploadFile
 import com.estivensh4.shared.SampleViewModel
 import kotlinx.coroutines.launch
 import java.awt.FileDialog
@@ -54,7 +54,7 @@ fun App() {
                             sampleViewModel.putObject(
                                 bucketName = bucketName,
                                 key = it.name,
-                                imageFile = ImageFile(
+                                uploadFile = UploadFile(
                                     uri = it.toURI()
                                 )
                             )

--- a/samples/iosApp/iosApp/ContentView.swift
+++ b/samples/iosApp/iosApp/ContentView.swift
@@ -70,7 +70,7 @@ struct ContentView: View {
 
                 if let selectedImageData,
                    let uiImage = UIImage(data: selectedImageData) {
-                    sampleViewModel.putObject(bucketName: bucketName, key: key, imageFile: .init(uiImage: uiImage))
+                    sampleViewModel.putObject(bucketName: bucketName, key: key, uploadFile: uiImage.toPNGUploadFile())
                 }
             
                 

--- a/samples/shared/src/commonMain/kotlin/com/estivensh4/shared/SampleViewModel.kt
+++ b/samples/shared/src/commonMain/kotlin/com/estivensh4/shared/SampleViewModel.kt
@@ -2,7 +2,7 @@ package com.estivensh4.shared
 
 import com.estivensh4.s3.AWSS3
 import com.estivensh4.s3.Bucket
-import com.estivensh4.s3.ImageFile
+import com.estivensh4.s3.UploadFile
 import com.rickclephas.kmm.viewmodel.KMMViewModel
 import com.rickclephas.kmm.viewmodel.MutableStateFlow
 import com.rickclephas.kmp.nativecoroutines.NativeCoroutinesState
@@ -66,9 +66,9 @@ open class SampleViewModel : KMMViewModel() {
         }
     }
 
-    fun putObject(bucketName: String, key: String, imageFile: ImageFile) {
+    fun putObject(bucketName: String, key: String, uploadFile: UploadFile) {
         GlobalScope.launch {
-            client.putObject(bucketName, key, imageFile)
+            client.putObject(bucketName, key, uploadFile)
         }
     }
 }

--- a/samples/wearapp/src/main/java/com/estivensh4/wearapp/presentation/MainActivity.kt
+++ b/samples/wearapp/src/main/java/com/estivensh4/wearapp/presentation/MainActivity.kt
@@ -29,7 +29,7 @@ import androidx.wear.compose.material.ScalingLazyColumn
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.material.TimeText
 import androidx.wear.compose.material.rememberScalingLazyListState
-import com.estivensh4.s3.ImageFile
+import com.estivensh4.s3.UploadFile
 import com.estivensh4.shared.SampleViewModel
 import com.estivensh4.wearapp.presentation.theme.ExampleTheme
 import kotlinx.datetime.Clock
@@ -63,7 +63,7 @@ fun WearApp() {
                 sampleViewModel.putObject(
                     bucketName = bucketName,
                     key = key,
-                    imageFile = ImageFile(
+                    uploadFile = UploadFile(
                         uri = it,
                         contentResolver = context.contentResolver
                     )


### PR DESCRIPTION
A PR for issue https://github.com/estivensh4/aws-kmp/issues/59

_The change is breaking, but I think it's worth it._

- Made putObject take an a generic 'UploadFile' instead of image
- Renamed ImageFile to UploadFile
- Changed UploadFile iOS implementation to be backed with NSData instead of UIImage.
- Added an extension UIImage.toPNGUploadFile() to support the image case on iOS